### PR TITLE
Add RDP to doubleclick action combobox

### DIFF
--- a/src/DeviceSettingsForm.Designer.cs
+++ b/src/DeviceSettingsForm.Designer.cs
@@ -30,6 +30,7 @@
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(DeviceSettingsForm));
             this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.collapseCheckBox = new System.Windows.Forms.CheckBox();
             this.checkForUpdatedCheckBox = new System.Windows.Forms.CheckBox();
             this.systemTrayCheckBox = new System.Windows.Forms.CheckBox();
             this.doubleClickComboBox = new System.Windows.Forms.ComboBox();
@@ -39,7 +40,6 @@
             this.exp_KeyboardHookCheckBox = new System.Windows.Forms.CheckBox();
             this.exp_KeyboardHookPriorityCheckBox = new System.Windows.Forms.CheckBox();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
-            this.collapseCheckBox = new System.Windows.Forms.CheckBox();
             this.groupBox1.SuspendLayout();
             this.groupBox2.SuspendLayout();
             this.SuspendLayout();
@@ -54,6 +54,12 @@
             this.groupBox1.Controls.Add(this.label1);
             this.groupBox1.Name = "groupBox1";
             this.groupBox1.TabStop = false;
+            // 
+            // collapseCheckBox
+            // 
+            resources.ApplyResources(this.collapseCheckBox, "collapseCheckBox");
+            this.collapseCheckBox.Name = "collapseCheckBox";
+            this.collapseCheckBox.UseVisualStyleBackColor = true;
             // 
             // checkForUpdatedCheckBox
             // 
@@ -79,7 +85,8 @@
             resources.GetString("doubleClickComboBox.Items4"),
             resources.GetString("doubleClickComboBox.Items5"),
             resources.GetString("doubleClickComboBox.Items6"),
-            resources.GetString("doubleClickComboBox.Items7")});
+            resources.GetString("doubleClickComboBox.Items7"),
+            resources.GetString("doubleClickComboBox.Items8")});
             resources.ApplyResources(this.doubleClickComboBox, "doubleClickComboBox");
             this.doubleClickComboBox.Name = "doubleClickComboBox";
             // 
@@ -122,12 +129,6 @@
             this.groupBox2.Controls.Add(this.exp_KeyboardHookCheckBox);
             this.groupBox2.Name = "groupBox2";
             this.groupBox2.TabStop = false;
-            // 
-            // collapseCheckBox
-            // 
-            resources.ApplyResources(this.collapseCheckBox, "collapseCheckBox");
-            this.collapseCheckBox.Name = "collapseCheckBox";
-            this.collapseCheckBox.UseVisualStyleBackColor = true;
             // 
             // DeviceSettingsForm
             // 

--- a/src/DeviceSettingsForm.resx
+++ b/src/DeviceSettingsForm.resx
@@ -130,10 +130,13 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="collapseCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>14, 93</value>
+    <value>28, 179</value>
+  </data>
+  <data name="collapseCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 6, 6, 6</value>
   </data>
   <data name="collapseCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>150, 17</value>
+    <value>300, 29</value>
   </data>
   <data name="collapseCheckBox.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -160,10 +163,13 @@
     <value>NoControl</value>
   </data>
   <data name="checkForUpdatedCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>14, 116</value>
+    <value>28, 223</value>
+  </data>
+  <data name="checkForUpdatedCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 6, 6, 6</value>
   </data>
   <data name="checkForUpdatedCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>113, 17</value>
+    <value>219, 29</value>
   </data>
   <data name="checkForUpdatedCheckBox.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -190,10 +196,13 @@
     <value>NoControl</value>
   </data>
   <data name="systemTrayCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>14, 70</value>
+    <value>28, 135</value>
+  </data>
+  <data name="systemTrayCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 6, 6, 6</value>
   </data>
   <data name="systemTrayCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>123, 17</value>
+    <value>243, 29</value>
   </data>
   <data name="systemTrayCheckBox.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -232,16 +241,22 @@
     <value>HTTPS</value>
   </data>
   <data name="doubleClickComboBox.Items6" xml:space="preserve">
-    <value>SSH</value>
+    <value>RDP</value>
   </data>
   <data name="doubleClickComboBox.Items7" xml:space="preserve">
+    <value>SSH</value>
+  </data>
+  <data name="doubleClickComboBox.Items8" xml:space="preserve">
     <value>SCP</value>
   </data>
   <data name="doubleClickComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>14, 43</value>
+    <value>28, 83</value>
+  </data>
+  <data name="doubleClickComboBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 6, 6, 6</value>
   </data>
   <data name="doubleClickComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>267, 21</value>
+    <value>530, 33</value>
   </data>
   <data name="doubleClickComboBox.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -262,10 +277,13 @@
     <value>True</value>
   </data>
   <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 24</value>
+    <value>24, 46</value>
+  </data>
+  <data name="label1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 0, 6, 0</value>
   </data>
   <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 13</value>
+    <value>199, 25</value>
   </data>
   <data name="label1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -286,10 +304,16 @@
     <value>4</value>
   </data>
   <data name="groupBox1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 12</value>
+    <value>24, 23</value>
+  </data>
+  <data name="groupBox1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 6, 6, 6</value>
+  </data>
+  <data name="groupBox1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 6, 6, 6</value>
   </data>
   <data name="groupBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>294, 141</value>
+    <value>588, 271</value>
   </data>
   <data name="groupBox1.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -316,10 +340,13 @@
     <value>NoControl</value>
   </data>
   <data name="okButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>150, 240</value>
+    <value>300, 462</value>
+  </data>
+  <data name="okButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 6, 6, 6</value>
   </data>
   <data name="okButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
+    <value>150, 44</value>
   </data>
   <data name="okButton.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -346,10 +373,13 @@
     <value>NoControl</value>
   </data>
   <data name="cancelButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>231, 240</value>
+    <value>462, 462</value>
+  </data>
+  <data name="cancelButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 6, 6, 6</value>
   </data>
   <data name="cancelButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
+    <value>150, 44</value>
   </data>
   <data name="cancelButton.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -376,10 +406,13 @@
     <value>NoControl</value>
   </data>
   <data name="exp_KeyboardHookCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>14, 22</value>
+    <value>28, 42</value>
+  </data>
+  <data name="exp_KeyboardHookCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 6, 6, 6</value>
   </data>
   <data name="exp_KeyboardHookCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>161, 17</value>
+    <value>314, 29</value>
   </data>
   <data name="exp_KeyboardHookCheckBox.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -406,10 +439,13 @@
     <value>NoControl</value>
   </data>
   <data name="exp_KeyboardHookPriorityCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>14, 45</value>
+    <value>28, 87</value>
+  </data>
+  <data name="exp_KeyboardHookPriorityCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 6, 6, 6</value>
   </data>
   <data name="exp_KeyboardHookPriorityCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>149, 17</value>
+    <value>296, 29</value>
   </data>
   <data name="exp_KeyboardHookPriorityCheckBox.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -433,10 +469,16 @@
     <value>Top, Bottom, Left, Right</value>
   </data>
   <data name="groupBox2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 159</value>
+    <value>24, 306</value>
+  </data>
+  <data name="groupBox2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 6, 6, 6</value>
+  </data>
+  <data name="groupBox2.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 6, 6, 6</value>
   </data>
   <data name="groupBox2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>294, 75</value>
+    <value>588, 144</value>
   </data>
   <data name="groupBox2.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -460,10 +502,10 @@
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
+    <value>12, 25</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>318, 275</value>
+    <value>636, 529</value>
   </data>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
@@ -2159,8 +2201,8 @@
         AADAPwAAwD8AAMA/AADAPwAA
 </value>
   </data>
-  <data name="$this.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
+  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 6, 6, 6</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterParent</value>


### PR DESCRIPTION
The doubleclick combobox was missing the RDP entry.
Might be better to fill this list dynamically, so the Index will always correspond with the correct item, but at least it's working now.
Fixes #27